### PR TITLE
[SS-14] creating image deployment flow

### DIFF
--- a/.github/workflows/ghcr-deploy.yml
+++ b/.github/workflows/ghcr-deploy.yml
@@ -1,0 +1,43 @@
+name: Create and publish a Docker image to gh registry
+
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+
+env:
+    REGISTRY: ghcr.io
+    IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+    build-and-push:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+            attestations: write
+            id-token: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+            - name: Log in to the Container registry
+              uses: docker/login-action@v2
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            - name: Build and push Docker image
+              id: push
+              uses: docker/build-push-action@v2
+              with:
+                  context: .
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ghcr-deploy.yml
+++ b/.github/workflows/ghcr-deploy.yml
@@ -1,10 +1,11 @@
-name: Create and publish a Docker image to gh registry
+# based off of https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+name: Create and publish a Docker image
 
 on:
     push:
-        branches:
-            - main
-    workflow_dispatch:
+        # Push events to `release/*` branches will trigger the workflow
+        # for example, `release/1.0.0`, `release/1.0.1`, `release/2.0.0`
+        branches: ["release/*"]
 
 env:
     REGISTRY: ghcr.io

--- a/.github/workflows/ghcr-deploy.yml
+++ b/.github/workflows/ghcr-deploy.yml
@@ -6,6 +6,7 @@ on:
         # Push events to `release/*` branches will trigger the workflow
         # for example, `release/1.0.0`, `release/1.0.1`, `release/2.0.0`
         branches: ["release/*"]
+    workflow_dispatch:
 
 env:
     REGISTRY: ghcr.io


### PR DESCRIPTION
this should deploy to our organization's container registry (https://github.com/orgs/Star-Sync/packages), this way we can access the images without the source code

two ways to make a new release

1. either manual dispatch (github ui)
2. a merge into `release/*` (this sounds like a good idea but maybe there is a better way to handle this)