### PR TITLE
[SS-28] Implemented UI Settings Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
+        "framer-motion": "^11.11.11",
         "lucide-react": "^0.454.0",
         "next": "14.2.14",
         "react": "^18",
@@ -3479,6 +3480,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.11.11",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.11.11.tgz",
+      "integrity": "sha512-tuDH23ptJAKUHGydJQII9PhABNJBpB+z0P1bmgKK9QFIssHGlfPd6kxMq00LSKwE27WFsb2z0ovY0bpUyMvfRw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
+    "framer-motion": "^11.11.11",
     "lucide-react": "^0.454.0",
     "next": "14.2.14",
     "react": "^18",

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,18 +1,8 @@
 import {
-    BookOpen,
-    Bot,
-    ChevronRight,
-    ChevronsUpDown, CogIcon,
-    Folder,
-    Forward,
-    Frame,
+    ChevronsUpDown,
+    CogIcon,
+    LayoutDashboard,
     LogOut,
-    Map,
-    MoreHorizontal,
-    PieChart,
-    Settings2,
-    SquareTerminal,
-    Trash2,
 } from "lucide-react"
 
 import {
@@ -20,11 +10,6 @@ import {
     AvatarFallback,
     AvatarImage,
 } from "@/components/ui/avatar"
-import {
-    Collapsible,
-    CollapsibleContent,
-    CollapsibleTrigger,
-} from "@/components/ui/collapsible"
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -39,20 +24,15 @@ import {
     SidebarContent,
     SidebarFooter,
     SidebarGroup,
-    SidebarGroupLabel,
     SidebarHeader,
     SidebarMenu,
-    SidebarMenuAction,
     SidebarMenuButton,
     SidebarMenuItem,
-    SidebarMenuSub,
-    SidebarMenuSubButton,
-    SidebarMenuSubItem,
-    SidebarRail,
     useSidebar,
 } from "@/components/ui/sidebar"
 import Image from "next/image";
 import {FaQuestionCircle} from "react-icons/fa";
+import {useIsMobile} from "@/hooks/use-mobile";
 
 const data = {
     user: {
@@ -62,106 +42,9 @@ const data = {
     },
     navMain: [
         {
-            title: "Playground",
-            url: "#",
-            icon: SquareTerminal,
+            title: "Dashboard",
+            url: "/dashboard",
             isActive: true,
-            items: [
-                {
-                    title: "History",
-                    url: "#",
-                },
-                {
-                    title: "Starred",
-                    url: "#",
-                },
-                {
-                    title: "Settings",
-                    url: "#",
-                },
-            ],
-        },
-        {
-            title: "Models",
-            url: "#",
-            icon: Bot,
-            items: [
-                {
-                    title: "Genesis",
-                    url: "#",
-                },
-                {
-                    title: "Explorer",
-                    url: "#",
-                },
-                {
-                    title: "Quantum",
-                    url: "#",
-                },
-            ],
-        },
-        {
-            title: "Documentation",
-            url: "#",
-            icon: BookOpen,
-            items: [
-                {
-                    title: "Introduction",
-                    url: "#",
-                },
-                {
-                    title: "Get Started",
-                    url: "#",
-                },
-                {
-                    title: "Tutorials",
-                    url: "#",
-                },
-                {
-                    title: "Changelog",
-                    url: "#",
-                },
-            ],
-        },
-        {
-            title: "Settings",
-            url: "#",
-            icon: Settings2,
-            items: [
-                {
-                    title: "General",
-                    url: "#",
-                },
-                {
-                    title: "Team",
-                    url: "#",
-                },
-                {
-                    title: "Billing",
-                    url: "#",
-                },
-                {
-                    title: "Limits",
-                    url: "#",
-                },
-            ],
-        },
-    ],
-    projects: [
-        {
-            name: "Design Engineering",
-            url: "#",
-            icon: Frame,
-        },
-        {
-            name: "Sales & Marketing",
-            url: "#",
-            icon: PieChart,
-        },
-        {
-            name: "Travel",
-            url: "#",
-            icon: Map,
         },
     ],
 }
@@ -170,120 +53,49 @@ export function AppSidebar() {
 
     const {state} = useSidebar()
     const isCollapsed = state === "collapsed"
+    const isMobile = useIsMobile()
     return (
 
         <div>
             <Sidebar collapsible="icon">
-                <SidebarHeader>
-                    <div
-                        className={`flex items-center justify-center h-full transition-all duration-300 ${isCollapsed ? 'w-16' : 'w-64'}`}>
-                        {!isCollapsed ? (
+                <SidebarHeader className="mt-3 ml-1 flex items-center justify-center transition-all duration-300">
+                        {!isCollapsed || isMobile ? (
                             <Image
                                 src="/ss-logo-full.png"
                                 alt="Wide Logo"
                                 width={128}
                                 height={64}
-                                className="transition-all duration-300 mt-4 -ml-5"
+                                className="transition-all duration-300 mt-4"
                             />
                         ) : (
                             <Image
                                 src="/favicon.png"
                                 alt="Square Logo"
-                                width={24}
-                                height={24}
-                                className="transition-all duration-300 -ml-8"
+                                width={30}
+                                height={30}
+                                className="transition-all duration-300"
                             />
                         )}
-                    </div>
                 </SidebarHeader>
-                <SidebarContent>
+                <SidebarContent  className="ml-1">
                     <SidebarGroup>
-                        <SidebarGroupLabel>Dashboard</SidebarGroupLabel>
                         <SidebarMenu>
                             {data.navMain.map((item) => (
-                                <Collapsible
-                                    key={item.title}
-                                    asChild
-                                    defaultOpen={item.isActive}
-                                    className="group/collapsible"
-                                >
-                                    <SidebarMenuItem>
-                                        <CollapsibleTrigger asChild>
-                                            <SidebarMenuButton tooltip={item.title}>
-                                                {item.icon && <item.icon/>}
-                                                <span>{item.title}</span>
-                                                <ChevronRight
-                                                    className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"/>
-                                            </SidebarMenuButton>
-                                        </CollapsibleTrigger>
-                                        <CollapsibleContent>
-                                            <SidebarMenuSub>
-                                                {item.items?.map((subItem) => (
-                                                    <SidebarMenuSubItem key={subItem.title}>
-                                                        <SidebarMenuSubButton asChild>
-                                                            <a href={subItem.url}>
-                                                                <span>{subItem.title}</span>
-                                                            </a>
-                                                        </SidebarMenuSubButton>
-                                                    </SidebarMenuSubItem>
-                                                ))}
-                                            </SidebarMenuSub>
-                                        </CollapsibleContent>
-                                    </SidebarMenuItem>
-                                </Collapsible>
-                            ))}
-                        </SidebarMenu>
-                    </SidebarGroup>
-                    <SidebarGroup className="group-data-[collapsible=icon]:hidden">
-                        <SidebarGroupLabel>Projects</SidebarGroupLabel>
-                        <SidebarMenu>
-                            {data.projects.map((item) => (
-                                <SidebarMenuItem key={item.name}>
-                                    <SidebarMenuButton asChild>
-                                        <a href={item.url}>
-                                            <item.icon/>
-                                            <span>{item.name}</span>
-                                        </a>
+                                <SidebarMenuItem key={item.title} asChild>
+                                    <SidebarMenuButton href={item.url} active={item.isActive}>
+                                        {item.title === "Dashboard" ? (
+                                            <span className="icon"><LayoutDashboard /></span>
+                                        ) : item.title === "Settings" ? (
+                                            <span className="icon"><CogIcon /></span>
+                                        ) : null}
+                                        <span className="">{item.title}</span>
                                     </SidebarMenuButton>
-                                    <DropdownMenu>
-                                        <DropdownMenuTrigger asChild>
-                                            <SidebarMenuAction showOnHover>
-                                                <MoreHorizontal/>
-                                                <span className="sr-only">More</span>
-                                            </SidebarMenuAction>
-                                        </DropdownMenuTrigger>
-                                        <DropdownMenuContent
-                                            className="w-48 rounded-lg"
-                                            side="bottom"
-                                            align="end"
-                                        >
-                                            <DropdownMenuItem>
-                                                <Folder className="text-muted-foreground"/>
-                                                <span>View Project</span>
-                                            </DropdownMenuItem>
-                                            <DropdownMenuItem>
-                                                <Forward className="text-muted-foreground"/>
-                                                <span>Share Project</span>
-                                            </DropdownMenuItem>
-                                            <DropdownMenuSeparator/>
-                                            <DropdownMenuItem>
-                                                <Trash2 className="text-muted-foreground"/>
-                                                <span>Delete Project</span>
-                                            </DropdownMenuItem>
-                                        </DropdownMenuContent>
-                                    </DropdownMenu>
                                 </SidebarMenuItem>
                             ))}
-                            <SidebarMenuItem>
-                                <SidebarMenuButton className="text-sidebar-foreground/70">
-                                    <MoreHorizontal className="text-sidebar-foreground/70"/>
-                                    <span>More</span>
-                                </SidebarMenuButton>
-                            </SidebarMenuItem>
                         </SidebarMenu>
                     </SidebarGroup>
                 </SidebarContent>
-                <SidebarFooter>
+                <SidebarFooter className={`flex items-center justify-center ${isMobile || isCollapsed ? 'ml-2' : ''}`}>
                     <SidebarMenu>
                         <SidebarMenuItem>
                             <DropdownMenu>
@@ -361,7 +173,6 @@ export function AppSidebar() {
                         </SidebarMenuItem>
                     </SidebarMenu>
                 </SidebarFooter>
-                <SidebarRail/>
             </Sidebar>
         </div>
     )

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,15 +1,26 @@
+"use client"
+
+// External Libraries
+import React from "react";
+import Image from "next/image";
+import { FaQuestionCircle } from "react-icons/fa";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { useRouter } from "next/navigation";
+
+// Icons
 import {
     ChevronsUpDown,
     CogIcon,
     LayoutDashboard,
     LogOut,
-} from "lucide-react"
+} from "lucide-react";
 
+// UI Components
 import {
     Avatar,
     AvatarFallback,
     AvatarImage,
-} from "@/components/ui/avatar"
+} from "@/components/ui/avatar";
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -18,7 +29,7 @@ import {
     DropdownMenuLabel,
     DropdownMenuSeparator,
     DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+} from "@/components/ui/dropdown-menu";
 import {
     Sidebar,
     SidebarContent,
@@ -29,151 +40,160 @@ import {
     SidebarMenuButton,
     SidebarMenuItem,
     useSidebar,
-} from "@/components/ui/sidebar"
-import Image from "next/image";
-import {FaQuestionCircle} from "react-icons/fa";
-import {useIsMobile} from "@/hooks/use-mobile";
+} from "@/components/ui/sidebar";
 
+// Data
 const data = {
     user: {
         name: "Sathira Williams",
         email: "sathira.williams@gmail.com",
-        avatar: "/favicon.png",
+        avatar: "/ss-logo-favicon.png",
+        role: "CSA Admin",
     },
     navMain: [
         {
             title: "Dashboard",
             url: "/dashboard",
             isActive: true,
+            icon: LayoutDashboard,
+        },
+        {
+            title: "Settings",
+            url: "/settings",
+            isActive: false,
+            icon: CogIcon,
         },
     ],
+};
+
+// Logo Component
+function Logo({ isCollapsed, isMobile }) {
+    return (
+        <SidebarHeader className="mt-3 ml-1 flex items-center justify-center transition-all duration-300">
+            {!isCollapsed || isMobile ? (
+                <Image
+                    src="/ss-logo-full.png"
+                    alt="Wide Logo"
+                    width={128}
+                    height={64}
+                    className="transition-all duration-300 mt-4"
+                />
+            ) : (
+                <Image
+                    src="/favicon.png"
+                    alt="Square Logo"
+                    width={30}
+                    height={30}
+                    className="transition-all duration-300"
+                />
+            )}
+        </SidebarHeader>
+    );
 }
 
-export function AppSidebar() {
-
-    const {state} = useSidebar()
-    const isCollapsed = state === "collapsed"
-    const isMobile = useIsMobile()
+// Navigation Menu Component
+function NavigationMenu({ navMain }) {
+    const router = useRouter();
     return (
-
-        <div>
-            <Sidebar collapsible="icon">
-                <SidebarHeader className="mt-3 ml-1 flex items-center justify-center transition-all duration-300">
-                        {!isCollapsed || isMobile ? (
-                            <Image
-                                src="/ss-logo-full.png"
-                                alt="Wide Logo"
-                                width={128}
-                                height={64}
-                                className="transition-all duration-300 mt-4"
-                            />
-                        ) : (
-                            <Image
-                                src="/favicon.png"
-                                alt="Square Logo"
-                                width={30}
-                                height={30}
-                                className="transition-all duration-300"
-                            />
-                        )}
-                </SidebarHeader>
-                <SidebarContent  className="ml-1">
-                    <SidebarGroup>
-                        <SidebarMenu>
-                            {data.navMain.map((item) => (
-                                <SidebarMenuItem key={item.title} asChild>
-                                    <SidebarMenuButton href={item.url} active={item.isActive}>
-                                        {item.title === "Dashboard" ? (
-                                            <span className="icon"><LayoutDashboard /></span>
-                                        ) : item.title === "Settings" ? (
-                                            <span className="icon"><CogIcon /></span>
-                                        ) : null}
-                                        <span className="">{item.title}</span>
-                                    </SidebarMenuButton>
-                                </SidebarMenuItem>
-                            ))}
-                        </SidebarMenu>
-                    </SidebarGroup>
-                </SidebarContent>
-                <SidebarFooter className={`flex items-center justify-center ${isMobile || isCollapsed ? 'ml-2' : ''}`}>
-                    <SidebarMenu>
-                        <SidebarMenuItem>
-                            <DropdownMenu>
-                                <DropdownMenuTrigger asChild>
-                                    <SidebarMenuButton
-                                        size="lg"
-                                        className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
-                                    >
-                                        <Avatar className="h-8 w-8 rounded-lg">
-                                            <AvatarImage
-                                                src={data.user.avatar}
-                                                alt={data.user.name}
-                                            />
-                                            <AvatarFallback className="rounded-lg">CN</AvatarFallback>
-                                        </Avatar>
-                                        <div className="grid flex-1 text-left text-sm leading-tight">
-                                              <span className="truncate font-semibold">
-                                                {data.user.name}
-                                              </span>
-                                            <span className="truncate text-xs">
-                                                {data.user.email}
-                                            </span>
-                                        </div>
-                                        <ChevronsUpDown className="ml-auto size-4"/>
-                                    </SidebarMenuButton>
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent
-                                    className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
-                                    side="bottom"
-                                    align="end"
-                                    sideOffset={4}
-                                >
-                                    <DropdownMenuLabel className="p-0 font-normal">
-                                        <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                                            <Avatar className="h-8 w-8 rounded-lg">
-                                                <AvatarImage
-                                                    src={data.user.avatar}
-                                                    alt={data.user.name}
-                                                />
-                                                <AvatarFallback className="rounded-lg">
-                                                    CN
-                                                </AvatarFallback>
-                                            </Avatar>
-                                            <div className="grid flex-1 text-left text-sm leading-tight">
-                                                <span className="truncate font-semibold">
-                                                  {data.user.name}
-                                                </span>
-                                                <span className="truncate text-xs">
-                                                  {data.user.email}
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </DropdownMenuLabel>
-                                    <DropdownMenuSeparator/>
-                                    <DropdownMenuGroup>
-                                    </DropdownMenuGroup>
-                                    <DropdownMenuSeparator/>
-                                    <DropdownMenuGroup>
-                                        <DropdownMenuItem>
-                                            <FaQuestionCircle/>
-                                            Help
-                                        </DropdownMenuItem>
-                                        <DropdownMenuItem>
-                                            <CogIcon/>
-                                            Settings
-                                        </DropdownMenuItem>
-                                    </DropdownMenuGroup>
-                                    <DropdownMenuSeparator/>
-                                    <DropdownMenuItem>
-                                        <LogOut/>
-                                        Log out
-                                    </DropdownMenuItem>
-                                </DropdownMenuContent>
-                            </DropdownMenu>
+        <SidebarGroup>
+            <SidebarMenu>
+                {navMain.map((item) => {
+                    const IconComponent = item.icon;
+                    return (
+                        <SidebarMenuItem key={item.title} asChild onClick={() => router.push(item.url)}>
+                            <SidebarMenuButton href={item.url} active={item.isActive}>
+                                {IconComponent && (
+                                    <span className="icon">
+                                        <IconComponent />
+                                    </span>
+                                )}
+                                <span>{item.title}</span>
+                            </SidebarMenuButton>
                         </SidebarMenuItem>
-                    </SidebarMenu>
-                </SidebarFooter>
-            </Sidebar>
-        </div>
-    )
+                    );
+                })}
+            </SidebarMenu>
+        </SidebarGroup>
+    );
+}
+
+// User Dropdown Menu Component
+function UserDropdownMenu({ user }) {
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <SidebarMenuButton
+                    size="lg"
+                    className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                >
+                    <Avatar className="h-8 w-8 rounded-lg">
+                        <AvatarImage src={user.avatar} alt={user.name} />
+                        <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+                    </Avatar>
+                    <div className="grid flex-1 text-left text-sm leading-tight">
+                        <span className="truncate font-semibold">{user.name}</span>
+                        <span className="truncate text-xs">{user.email}</span>
+                    </div>
+                    <ChevronsUpDown className="ml-auto size-4" />
+                </SidebarMenuButton>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+                className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+                side="bottom"
+                align="end"
+                sideOffset={4}
+            >
+                <DropdownMenuLabel className="p-0 font-normal">
+                    <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                        <Avatar className="h-8 w-8 rounded-lg">
+                            <AvatarImage src={user.avatar} alt={user.name} />
+                            <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+                        </Avatar>
+                        <div className="grid flex-1 text-left text-sm leading-tight">
+                            <span className="truncate font-semibold">{user.name}</span>
+                            <span className="truncate text-xs">{user.role}</span>
+                        </div>
+                    </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuGroup>
+                    <DropdownMenuItem>
+                        <FaQuestionCircle />
+                        Help
+                    </DropdownMenuItem>
+                </DropdownMenuGroup>
+                <DropdownMenuItem>
+                    <LogOut />
+                    Log out
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}
+
+// Main AppSidebar Component
+export function AppSidebar() {
+    const { state } = useSidebar();
+    const isCollapsed = state === "collapsed";
+    const isMobile = useIsMobile();
+
+    return (
+        <Sidebar collapsible="icon">
+            <Logo isCollapsed={isCollapsed} isMobile={isMobile} />
+            <SidebarContent className="ml-1">
+                <NavigationMenu navMain={data.navMain} />
+            </SidebarContent>
+            <SidebarFooter
+                className={`flex items-center justify-center ${
+                    isMobile || isCollapsed ? "ml-2" : ""
+                }`}
+            >
+                <SidebarMenu>
+                    <SidebarMenuItem>
+                        <UserDropdownMenu user={data.user} />
+                    </SidebarMenuItem>
+                </SidebarMenu>
+            </SidebarFooter>
+        </Sidebar>
+    );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
@@ -21,7 +21,7 @@ const Header: React.FC = () => {
     const [opacity, setOpacity] = useState<number>(1);
     const [hover, setHover] = useState<boolean>(false);
 
-    const adjustOpacity = () => {
+    const adjustOpacity = useCallback(() => {
         if (open || hover) {
             setOpacity(1);
         } else {
@@ -29,11 +29,11 @@ const Header: React.FC = () => {
             const newOpacity = Math.max(1 - scrollY / 300, 0.5);
             setOpacity(newOpacity);
         }
-    };
+    }, [open, hover]);
 
     useEffect(() => {
         adjustOpacity();
-    }, [open, hover]);
+    }, [open, hover, adjustOpacity]);
 
     useEffect(() => {
         const handleScroll = () => {
@@ -41,7 +41,7 @@ const Header: React.FC = () => {
         };
         window.addEventListener('scroll', handleScroll);
         return () => window.removeEventListener('scroll', handleScroll);
-    }, [open, hover]);
+    }, [open, hover, adjustOpacity]);
 
     useEffect(() => {
         // Only access localStorage on the client side

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,6 +18,30 @@ const Header: React.FC = () => {
     const [time, setTime] = useState<string>("");
     const [timezone, setTimezone] = useState<string>("UTC");
     const [open, setOpen] = useState<boolean>(false);
+    const [opacity, setOpacity] = useState<number>(1);
+    const [hover, setHover] = useState<boolean>(false);
+
+    const adjustOpacity = () => {
+        if (open || hover) {
+            setOpacity(1);
+        } else {
+            const scrollY = window.scrollY;
+            const newOpacity = Math.max(1 - scrollY / 300, 0.5);
+            setOpacity(newOpacity);
+        }
+    };
+
+    useEffect(() => {
+        adjustOpacity();
+    }, [open, hover]);
+
+    useEffect(() => {
+        const handleScroll = () => {
+            adjustOpacity();
+        };
+        window.addEventListener('scroll', handleScroll);
+        return () => window.removeEventListener('scroll', handleScroll);
+    }, [open, hover]);
 
     useEffect(() => {
         const timer = setInterval(() => {
@@ -27,7 +51,7 @@ const Header: React.FC = () => {
                 hour: "2-digit",
                 minute: "2-digit",
                 second: "2-digit",
-                hour12: false, // Ensure 24-hour format
+                hour12: false,
             });
             const formattedTime = formatter.format(now);
             const locationName = timezones.find((tz) => tz.value === timezone)?.name || "";
@@ -38,12 +62,17 @@ const Header: React.FC = () => {
     }, [timezone]);
 
     return (
-        <header className="bg-white p-4 text-black">
-            <div className="relative flex items-center w-full">
+        <header
+            className="bg-white p-4 text-black sticky top-0 z-10"
+            style={{ opacity }}
+            onMouseEnter={() => setHover(true)}
+            onMouseLeave={() => setHover(false)}
+        >
+            <div className="relative flex items-center w-full header-content">
                 {/* Left Side */}
                 <div className="absolute left-0 flex items-center">
                     <SidebarTrigger />
-                    <Separator orientation="vertical" className="h-6 ml-1" />
+                    <Separator orientation="vertical" className="h-6 ml-3" />
                 </div>
 
                 {/* Centered Combo Box with Clock */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -44,6 +44,14 @@ const Header: React.FC = () => {
     }, [open, hover]);
 
     useEffect(() => {
+        // Only access localStorage on the client side
+        const savedTimezone = typeof window !== "undefined" ? localStorage.getItem("timezone") : "UTC";
+        if (savedTimezone) {
+            setTimezone(savedTimezone);
+        }
+    }, []);
+
+    useEffect(() => {
         const timer = setInterval(() => {
             const now = new Date();
             const formatter = new Intl.DateTimeFormat("en-US", {
@@ -60,6 +68,14 @@ const Header: React.FC = () => {
 
         return () => clearInterval(timer);
     }, [timezone]);
+
+    const handleTimezoneChange = (newTimezone: string) => {
+        setTimezone(newTimezone);
+        if (typeof window !== "undefined") {
+            localStorage.setItem("timezone", newTimezone);
+        }
+        setOpen(false);
+    };
 
     return (
         <header
@@ -100,10 +116,7 @@ const Header: React.FC = () => {
                                             <CommandItem
                                                 key={tz.value}
                                                 value={tz.value}
-                                                onSelect={() => {
-                                                    setTimezone(tz.value);
-                                                    setOpen(false);
-                                                }}
+                                                onSelect={() => handleTimezoneChange(tz.value)}
                                             >
                                                 {tz.label}
                                                 <Check

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import { SidebarProvider } from '@/components/ui/sidebar';
 import { AppSidebar } from '@/components/AppSidebar';
 import Header from '@/components/Header';
 
+
 type LayoutProps = {
     children: React.ReactNode;
 };
@@ -15,7 +16,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     return (
         <SidebarProvider>
             {!isHomepage && <AppSidebar />}
-            <main className="w-screen h-screen">
+            <main className="w-screen h-screen bg-white">
                 {!isHomepage && <Header />}
                 {children}
             </main>

--- a/src/components/settings/settings-general.tsx
+++ b/src/components/settings/settings-general.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const SettingsGeneral: React.FC = () => {
+    return (
+        <div>
+            <h3 className="text-xl font-semibold">General Settings</h3>
+            <p>General settings content goes here.</p>
+        </div>
+    );
+};
+
+export default SettingsGeneral;

--- a/src/components/ui/fade-text.tsx
+++ b/src/components/ui/fade-text.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useMemo } from "react";
+import { motion, Variants } from "framer-motion";
+
+type FadeTextProps = {
+  className?: string;
+  direction?: "up" | "down" | "left" | "right";
+  framerProps?: Variants;
+  text: string;
+};
+
+export function FadeText({
+  direction = "up",
+  className,
+  framerProps = {
+    hidden: { opacity: 0 },
+    show: { opacity: 1, transition: { type: "spring" } },
+  },
+  text,
+}: FadeTextProps) {
+  const directionOffset = useMemo(() => {
+    const map = { up: 10, down: -10, left: -10, right: 10 };
+    return map[direction];
+  }, [direction]);
+
+  const axis = direction === "up" || direction === "down" ? "y" : "x";
+
+  const FADE_ANIMATION_VARIANTS = useMemo(() => {
+    const { hidden, show, ...rest } = framerProps as {
+      [name: string]: { [name: string]: number; opacity: number };
+    };
+
+    return {
+      ...rest,
+      hidden: {
+        ...(hidden ?? {}),
+        opacity: hidden?.opacity ?? 0,
+        [axis]: hidden?.[axis] ?? directionOffset,
+      },
+      show: {
+        ...(show ?? {}),
+        opacity: show?.opacity ?? 1,
+        [axis]: show?.[axis] ?? 0,
+      },
+    };
+  }, [directionOffset, axis, framerProps]);
+
+  return (
+    <motion.div
+      initial="hidden"
+      animate="show"
+      viewport={{ once: true }}
+      variants={FADE_ANIMATION_VARIANTS}
+    >
+      <motion.span className={className}>{text}</motion.span>
+    </motion.div>
+  );
+}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -21,7 +21,7 @@ const SIDEBAR_COOKIE_NAME = "sidebar:state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = "16rem"
 const SIDEBAR_WIDTH_MOBILE = "18rem"
-const SIDEBAR_WIDTH_ICON = "3rem"
+const SIDEBAR_WIDTH_ICON = "4rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
 type SidebarContext = {

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,10 +1,17 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 const Dashboard: React.FC = () => {
+    const [isLoaded, setIsLoaded] = useState(false);
+
+    useEffect(() => {
+        setIsLoaded(true);
+    }, []);
+
     return (
-        <section className="w-full h-full flex flex-col bg-gray-700">
-            <div className="p-6 bg-gray-700 shadow-md rounded-lg">
-                <h2 className="text-2xl font-bold mb-4 text-white">Overview</h2>
+        <section className="w-full h-full bg-gray-50 p-4 space-y-4">
+            <div className={`bg-white rounded-xl p-6 shadow-md ${isLoaded ? 'fade-in' : ''}`}>
+                <h2 className="text-2xl font-bold text-black">Overview</h2>
+                <h2 className="text-md text-gray-500 mb-4">Manage your plan and billing history here.</h2>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div className="bg-blue-500 text-white p-4 rounded-lg shadow-md">
                         <h3 className="text-lg font-semibold">Scheduled Tasks</h3>
@@ -12,7 +19,6 @@ const Dashboard: React.FC = () => {
                     </div>
                     <div className="bg-green-500 text-white p-4 rounded-lg shadow-md">
                         <h3 className="text-lg font-semibold">Active Satellites</h3>
-
                         <p>Satellites in operation: 5</p>
                     </div>
                     <div className="bg-yellow-500 text-white p-4 rounded-lg shadow-md">
@@ -22,7 +28,6 @@ const Dashboard: React.FC = () => {
                 </div>
             </div>
         </section>
-
     );
 };
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,13 +1,57 @@
-import React from 'react';
-import {Separator} from "@/components/ui/separator";
+import React, {useEffect, useState} from 'react';
+import { Separator } from "@/components/ui/separator";
+import SettingsGeneral from "@/components/settings/settings-general";
+
+// Tab data and dynamic import of components for each tab content
+const tabs = [
+    { name: "General", key: "general", Component: SettingsGeneral },
+    { name: "Users", key: "users", Component: () => <div>User management settings content goes here.</div> },
+    { name: "Analytics", key: "analytics", Component: () => <div>Analytics settings content goes here.</div> },
+    { name: "Apps", key: "apps", Component: () => <div>Apps settings content goes here.</div> },
+    { name: "Security", key: "security", Component: () => <div>Security settings content goes here.</div> },
+    { name: "Billing", key: "billing", Component: () => <div>Billing settings content goes here.</div> },
+    { name: "API", key: "api", Component: () => <div>API settings content goes here.</div> },
+];
 
 const Settings: React.FC = () => {
+    const [activeTab, setActiveTab] = useState("general");
+    // Find the active tab object
+    const activeTabData = tabs.find((tab) => tab.key === activeTab);
+    const [isLoaded, setIsLoaded] = useState(false);
+
+    useEffect(() => {
+        setIsLoaded(true);
+    }, []);
+
     return (
-        <section className="w-full h-full bg-gray-100 p-4">
-            <div className="ml-12">
+        <section className="w-full h-full bg-gray-50 p-4 space-y-4">
+            {/* Heading Section */}
+            <div className={`bg-white rounded-xl p-6 shadow-md ${isLoaded ? 'fade-in' : ''}`}>
                 <h1 className="text-2xl font-bold text-black">Settings</h1>
-                <h2 className="text-md text-black">Manage and personalize settings</h2>
-                <Separator className="text-black"/>
+                <h2 className="text-md text-gray-500 mb-3">Manage your plan and billing history here.</h2>
+
+                {/* Tab Navigation */}
+                <div className="flex space-x-2 overflow-x-auto">
+                    {tabs.map((tab) => (
+                        <button
+                            key={tab.key}
+                            onClick={() => setActiveTab(tab.key)}
+                            className={`px-4 py-2 rounded-full border text-sm font-medium ${
+                                activeTab === tab.key
+                                    ? "bg-black text-white"
+                                    : "bg-gray-100 text-gray-800 hover:bg-gray-200"
+                            }`}
+                        >
+                            {tab.name}
+                        </button>
+                    ))}
+                </div>
+
+            </div>
+
+            {/* Content Section for Active Tab */}
+            <div className={`bg-white rounded-xl p-6 shadow-md ${isLoaded ? 'fade-in' : ''}`}>
+                {activeTabData?.Component && <activeTabData.Component/>}
             </div>
         </section>
     );

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,25 +1,15 @@
 import React from 'react';
+import {Separator} from "@/components/ui/separator";
 
 const Settings: React.FC = () => {
     return (
-            <div className="p-6 bg-white shadow-md rounded-lg">
-                <h2 className="text-2xl font-bold mb-4 text-black">Settings</h2>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <div className="bg-blue-500 text-white p-4 rounded-lg shadow-md">
-                        <h3 className="text-lg font-semibold">User Profile</h3>
-                        <p>Update your profile details</p>
-                    </div>
-                    <div className="bg-green-500 text-white p-4 rounded-lg shadow-md">
-                        <h3 className="text-lg font-semibold">Account Settings</h3>
-
-                        <p>Update your account settings</p>
-                    </div>
-                    <div className="bg-yellow-500 text-white p-4 rounded-lg shadow-md">
-                        <h3 className="text-lg font-semibold">Notification Preferences</h3>
-                        <p>Update your notification preferences</p>
-                    </div>
-                </div>
+        <section className="w-full h-full bg-gray-100 p-4">
+            <div className="ml-12">
+                <h1 className="text-2xl font-bold text-black">Settings</h1>
+                <h2 className="text-md text-black">Manage and personalize settings</h2>
+                <Separator className="text-black"/>
             </div>
+        </section>
     );
 };
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,5 +1,4 @@
 import React, {useEffect, useState} from 'react';
-import { Separator } from "@/components/ui/separator";
 import SettingsGeneral from "@/components/settings/settings-general";
 
 // Tab data and dynamic import of components for each tab content

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -106,3 +106,18 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-in {
+  animation: fadeIn 0.5s ease-out forwards;
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/948e25c3-f41a-48e1-83a8-9efbb2fb80a8)

Implemented settings page ui, with ability to expand in the future by adding to "/src/components/settings/".  

Additional features this pull:

- Scrolling down reduces opacity of header, and hovering reverses it
- Sidebar icons aligned to center in collapsed state
- Fade in card div on load of page
- Sidebar icons highlighted when on that page
- Clock timezone persists once changed and refreshed