### PR TITLE
[SS-132] Load Ground-Stations from Backend 

### DIFF
--- a/src/api/gs-locations.ts
+++ b/src/api/gs-locations.ts
@@ -1,10 +1,23 @@
+import apiClient from '@/lib/api';
+
 export interface Location {
-    station_id: string;
-    label: string;
+    id: number;
+    name: string;
+    lat: number;
+    lon: number;
+    height: number;
+    mask: number;
+    uplink: number;
+    downlink: number;
+    science: number;
 }
 
-export const locations: Location[] = [
-    { station_id: "1", label: "Inuvik Northwest" },
-    { station_id: "2", label: "Prince Albert" },
-    { station_id: "3", label: "Gatineau Quebec" },
-];
+export const getLocations = async (): Promise<Location[]> => {
+    try {
+        const response = await apiClient.get<Location[]>('/api/v1/gs');
+        return response.data;
+    } catch (error) {
+        console.error('Error fetching ground station locations:', error);
+        return [];
+    }
+};

--- a/src/api/gs-satellites.ts
+++ b/src/api/gs-satellites.ts
@@ -1,9 +1,22 @@
+import apiClient from '@/lib/api';
+
 export interface Satellite {
-    satellite_id: string;
-    label: string;
+    id: string;
+    name: string;
+    tle: string;
+    uplink: number;
+    telemetry: number;
+    science: number;
+    priority: number;
+    ex_cones?: any[];
 }
 
-export const satellites: Satellite[] = [
-    { satellite_id: "1", label: "SCISAT 1" },
-    { satellite_id: "2", label: "NEOSSAT" },
-];
+export const getSatellites = async (): Promise<Satellite[]> => {
+    try {
+        const response = await apiClient.get<Satellite[]>('/api/v1/satellites');
+        return response.data;
+    } catch (error) {
+        console.error('Error fetching satellites:', error);
+        return [];
+    }
+};

--- a/src/components/app/gs-scheduler/GSContainer.tsx
+++ b/src/components/app/gs-scheduler/GSContainer.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useState, useRef } from "react";
-import { Location } from "@/api/gs-locations";
 import { Tab } from "./TabNav";
 import MotionWrapper from "../MotionWrapper";
 import Scheduler from "@/components/app/gs-scheduler/Scheduler";

--- a/src/components/app/gs-scheduler/GSContainer.tsx
+++ b/src/components/app/gs-scheduler/GSContainer.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState, useRef } from "react";
-import { locations, Location } from "@/api/gs-locations";
+import { Location } from "@/api/gs-locations";
 import { Tab } from "./TabNav";
 import MotionWrapper from "../MotionWrapper";
 import Scheduler from "@/components/app/gs-scheduler/Scheduler";
@@ -9,7 +9,6 @@ import TabContent from "./TabContent";
 import HeaderSection from "./HeaderSection";
 
 const GSContainer: FC = () => {
-    const [selectedLocation, setSelectedLocation] = useState<Location>(locations[0]);
     const [tabs, setTabs] = useState<Tab[]>([
         {
             id: "scheduler",
@@ -27,7 +26,7 @@ const GSContainer: FC = () => {
         const newTab: Tab = {
             id: newTabId,
             name: `Request Form. ${tabCounter.current}`,
-            content: (location) => <RequestForm key={newTabId} location={location} />,
+            content: () => <RequestForm key={newTabId}/>,
         };
         setTabs((prevTabs) => [...prevTabs, newTab]);
         setActiveTabId(newTabId);
@@ -45,21 +44,10 @@ const GSContainer: FC = () => {
         }
     };
 
-    const handleLocationChange = (value: string) => {
-        const newLocation = locations.find((loc) => loc.station_id === value);
-        if (newLocation) {
-            setSelectedLocation(newLocation);
-        }
-    };
-
     return (
         <MotionWrapper className="w-full h-full flex flex-col bg-gray-50 p-6">
             <div className="bg-white rounded-xl p-6 shadow-lg flex flex-col h-full overflow-hidden">
-                <HeaderSection
-                    selectedLocation={selectedLocation}
-                    handleLocationChange={handleLocationChange}
-                    locations={locations}
-                />
+                <HeaderSection />
                 <TabNav
                     tabs={tabs}
                     activeTabId={activeTabId}
@@ -67,7 +55,7 @@ const GSContainer: FC = () => {
                     addNewTab={addNewTab}
                     closeTab={closeTab}
                 />
-                <TabContent tabs={tabs} activeTabId={activeTabId} selectedLocation={selectedLocation} />
+                <TabContent tabs={tabs} activeTabId={activeTabId} />
             </div>
         </MotionWrapper>
     );

--- a/src/components/app/gs-scheduler/HeaderSection.tsx
+++ b/src/components/app/gs-scheduler/HeaderSection.tsx
@@ -1,34 +1,10 @@
-import React, { FC } from "react";
-import Combobox from "@/components/ui/combobox";
-import { Location } from "@/api/gs-locations";
+import React from "react";
 
-interface HeaderSectionProps {
-    selectedLocation: Location;
-    handleLocationChange: (value: string) => void;
-    locations: Location[];
-}
-
-const HeaderSection: FC<HeaderSectionProps> = ({
-                                                   selectedLocation,
-                                                   handleLocationChange,
-                                                   locations,
-                                               }) => {
+const HeaderSection = () => {
     return (
         <div className="flex justify-between items-center mb-4">
             <div>
                 <h1 className="text-xl font-semibold text-black">Ground-Station Scheduling</h1>
-                <div className="flex items-center text-sm text-gray-500 mt-2">
-                    <Combobox
-                        items={locations.map((location) => ({
-                            value: location.station_id,
-                            label: location.label,
-                        }))}
-                        value={selectedLocation.station_id}
-                        onChange={handleLocationChange}
-                        placeholder="Select a location"
-                        className="w-56"
-                    />
-                </div>
             </div>
         </div>
     );

--- a/src/components/app/gs-scheduler/RequestForm/ContactRequestForm.tsx
+++ b/src/components/app/gs-scheduler/RequestForm/ContactRequestForm.tsx
@@ -57,7 +57,7 @@ const ContactRequestForm = ({ }) => {
     defaultValues: {
       missionName: "",
       satelliteId: "",
-      groundStationId: "",
+      station_id: "",
       orbit: "",
       uplink: false,
       telemetry: false,
@@ -125,7 +125,7 @@ const ContactRequestForm = ({ }) => {
                   {/* Ground Station Combobox */}
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-[25vw]">
                     <Controller
-                      name="groundStationId"
+                      name="station_id"
                       control={form.control}
                       render={({ field }) => (
                         <Combobox

--- a/src/components/app/gs-scheduler/RequestForm/ContactRequestForm.tsx
+++ b/src/components/app/gs-scheduler/RequestForm/ContactRequestForm.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { zodResolver } from "@hookform/resolvers/zod";
 import "react-datepicker/dist/react-datepicker.css";
 import { Separator } from "@/components/ui/separator";
 import { TimePickerField } from "@/components/ui/wrapper/timepickerfield";
-import { locations } from "@/api/gs-locations";
 import FormFieldWrapper from "@/components/ui/wrapper/formfieldwrapper";
 import CheckboxFieldWrapper from "@/components/ui/wrapper/checkboxfieldwrapper";
 import {
@@ -13,34 +12,52 @@ import {
   ContactRequestFormData,
 } from "./ContactRequestFormSchema";
 import Combobox from "@/components/ui/combobox";
-import { satellites } from "@/api/gs-satellites";
+import { getSatellites, Satellite } from "@/api/gs-satellites";
+import { getLocations, Location } from "@/api/gs-locations";
 import { formatToISOString } from "@/lib/formatToISOString";
 import apiClient from "@/lib/api";
 import { toast } from "@/hooks/use-toast";
 
-interface ContactRequestFormProps {
-  location: (typeof locations)[0];
-}
 
-const satelliteOptions = satellites
-  .filter((sat) => sat.satellite_id && sat.label)
-  .map((sat) => ({
-    value: sat.satellite_id.toString(),
-    label: sat.label,
-  }));
 
-const ContactRequestForm: React.FC<ContactRequestFormProps> = ({
-  location,
-}) => {
-  useEffect(() => {
-    console.log("ContactRequestForm: Location updated to", location.label);
-  }, [location]);
+const ContactRequestForm = ({ }) => {
+   const [groundStations, setGroundStations] = useState<Location[]>([]);
+   const [satellites, setSatellites] = useState<Satellite[]>([]);
+   
+    // Transform ground stations into combobox format
+    const groundStationOptions = groundStations.map((station) => ({
+      value: station.id.toString(),
+      label: station.name,
+    }));
+
+    const satelliteOptions = satellites.map((sat) => ({
+      value: sat.id.toString(),
+      label: sat.name,
+    }));
+  
+    useEffect(() => {
+      const fetchGroundStations = async () => {
+        const stations = await getLocations();
+        setGroundStations(stations);
+      };
+      fetchGroundStations();
+    }, []);
+
+    useEffect(() => {
+      const fetchSatellites = async () => {
+        const sats = await getSatellites();
+        setSatellites(sats);
+      };
+      fetchSatellites();
+    }
+, []);
 
   const form = useForm<ContactRequestFormData>({
     resolver: zodResolver(ContactRequestFormSchema),
     defaultValues: {
       missionName: "",
-      satelliteId: satelliteOptions[0]?.value || "",
+      satelliteId: "",
+      groundStationId: "",
       orbit: "",
       uplink: false,
       telemetry: false,
@@ -59,8 +76,6 @@ const ContactRequestForm: React.FC<ContactRequestFormProps> = ({
       rfOnTime: formatToISOString(values.rfOnTime),
       rfOffTime: formatToISOString(values.rfOffTime),
       losTime: formatToISOString(values.losTime),
-      location: location.label,
-      satellite_id: values.satelliteId,
     };
     // Send the request to the backend using apiClient
     try {
@@ -83,7 +98,9 @@ const ContactRequestForm: React.FC<ContactRequestFormProps> = ({
           "There was an error submitting the contact request. Please try again.",
         variant: "destructive",
         duration: 5000,
+        
       });
+      console.log(payload);
     }
   };
 
@@ -105,7 +122,24 @@ const ContactRequestForm: React.FC<ContactRequestFormProps> = ({
               />
             )}
           />
+                  {/* Ground Station Combobox */}
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-[25vw]">
+                    <Controller
+                      name="groundStationId"
+                      control={form.control}
+                      render={({ field }) => (
+                        <Combobox
+                          items={groundStationOptions}
+                          value={field.value}
+                          onChange={field.onChange}
+                          placeholder="Select a Ground Station"
+                          className="text-black"
+                        />
+                      )}
+                    />
+                  </div>
         </div>
+        
 
         <Separator className="max-w-[50vw]" />
 
@@ -157,8 +191,6 @@ const ContactRequestForm: React.FC<ContactRequestFormProps> = ({
         </div>
 
         <Separator className="max-w-[50vw]" />
-
-        <p className="text-sm text-gray-600">Location: {location.label}</p>
 
         {/* Submit Button */}
         <Button type="submit" className="w-full md:w-auto">

--- a/src/components/app/gs-scheduler/RequestForm/ContactRequestFormSchema.ts
+++ b/src/components/app/gs-scheduler/RequestForm/ContactRequestFormSchema.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const ContactRequestFormSchema = z.object({
     missionName: z.string().min(1, "Mission Name is required"),
     satelliteId: z.string().min(1, "Satellite is required"),
+    groundStationId: z.string().min(1, "Ground Station is required"),
     orbit: z.string().min(1, "Orbit is required"),
     uplink: z.boolean(),
     telemetry: z.boolean(),

--- a/src/components/app/gs-scheduler/RequestForm/ContactRequestFormSchema.ts
+++ b/src/components/app/gs-scheduler/RequestForm/ContactRequestFormSchema.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const ContactRequestFormSchema = z.object({
     missionName: z.string().min(1, "Mission Name is required"),
     satelliteId: z.string().min(1, "Satellite is required"),
-    groundStationId: z.string().min(1, "Ground Station is required"),
+    station_id: z.string().min(1, "Ground Station is required"),
     orbit: z.string().min(1, "Orbit is required"),
     uplink: z.boolean(),
     telemetry: z.boolean(),

--- a/src/components/app/gs-scheduler/RequestForm/RFRequestForm.tsx
+++ b/src/components/app/gs-scheduler/RequestForm/RFRequestForm.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from "react";
-import { locations } from "@/api/gs-locations";
+import React, { useState, useEffect } from "react";
 import { useForm, Controller, FormProvider } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -9,32 +8,32 @@ import { TimePickerField } from "@/components/ui/wrapper/timepickerfield";
 import FormFieldWrapper from "@/components/ui/wrapper/formfieldwrapper";
 import { RFRequestFormSchema, RFRequestFormData } from "./RFRequestFormSchema";
 import Combobox from "@/components/ui/combobox";
-import { satellites } from "@/api/gs-satellites";
+import { getSatellites, Satellite } from "@/api/gs-satellites";
 import apiClient from "@/lib/api";
 import { formatToISOString } from "@/lib/formatToISOString";
 import { toast } from "@/hooks/use-toast";
 
-interface RFRequestFormProps {
-  location: (typeof locations)[0];
-}
 
-const satelliteOptions = satellites
-  .filter((sat) => sat.satellite_id && sat.label)
-  .map((sat) => ({
-    value: sat.satellite_id.toString(),
-    label: sat.label,
+const RFRequestForm = () => {
+  const [satellites, setSatellites] = useState<Satellite[]>([]);
+  const satelliteOptions = satellites.map((sat) => ({
+    value: sat.id.toString(),
+    label: sat.name,
   }));
 
-const RFRequestForm: React.FC<RFRequestFormProps> = ({ location }) => {
-  useEffect(() => {
-    console.log("RFRequestForm: Location updated to", location.label);
-  }, [location]);
-
+   useEffect(() => {
+        const fetchSatellites = async () => {
+          const sats = await getSatellites();
+          setSatellites(sats);
+        };
+        fetchSatellites();
+      }, []);
+  
   const form = useForm<RFRequestFormData>({
     resolver: zodResolver(RFRequestFormSchema),
     defaultValues: {
       missionName: "",
-      satelliteId: satelliteOptions[0]?.value || "",
+      satelliteId: "",
       startTime: undefined,
       endTime: undefined,
       uplinkTime: 0,
@@ -51,11 +50,9 @@ const RFRequestForm: React.FC<RFRequestFormProps> = ({ location }) => {
       endTime: formatToISOString(values.endTime),
     };
 
-    // Send the request to the backend using apiClient
     try {
       const response = await apiClient.post("/api/v1/request/rf-time", payload);
       console.log("Successfully submitted:", response.data);
-      // Handle success
       toast({
         title: "Submission Success",
         description: "Successfully sent!" + response.data,
@@ -64,7 +61,6 @@ const RFRequestForm: React.FC<RFRequestFormProps> = ({ location }) => {
       });
     } catch (error) {
       console.error("Error submitting RFRequest:", error);
-      // Handle errors
       toast({
         title: "Submission Error: " + error,
         description: "Failed to submit!",

--- a/src/components/app/gs-scheduler/RequestForm/RequestForm.tsx
+++ b/src/components/app/gs-scheduler/RequestForm/RequestForm.tsx
@@ -1,14 +1,9 @@
 import React from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { motion } from "framer-motion";
-import { locations } from "@/api/gs-locations";
 import RFRequestForm from "./RFRequestForm";
 import ContactRequestForm from "./ContactRequestForm";
 import MotionWrapper from "@/components/app/MotionWrapper";
-
-interface RequestFormProps {
-    location: typeof locations[0];
-}
 
 const formVariants = {
     initial: { opacity: 0, scale: 0.95 },
@@ -18,7 +13,7 @@ const formVariants = {
 
 const transition = { duration: 0.4, ease: "easeInOut" };
 
-const RequestForm: React.FC<RequestFormProps> = ({ location }) => {
+const RequestForm = () => {
     return (
         <MotionWrapper>
             <Tabs defaultValue="contact" className="w-full">
@@ -38,7 +33,7 @@ const RequestForm: React.FC<RequestFormProps> = ({ location }) => {
                         exit="exit"
                         transition={transition}
                     >
-                        <ContactRequestForm location={location}/>
+                        <ContactRequestForm/>
                     </motion.div>
                 </TabsContent>
                 <TabsContent value="rf">
@@ -50,7 +45,7 @@ const RequestForm: React.FC<RequestFormProps> = ({ location }) => {
                         exit="exit"
                         transition={transition}
                     >
-                        <RFRequestForm location={location} />
+                        <RFRequestForm/>
                     </motion.div>
                 </TabsContent>
             </Tabs>

--- a/src/components/app/gs-scheduler/TabContent.tsx
+++ b/src/components/app/gs-scheduler/TabContent.tsx
@@ -1,15 +1,13 @@
 import React, { FC } from "react";
 import { motion } from "framer-motion";
-import {Location } from "@/api/gs-locations";
 import { Tab } from "./TabNav";
 
 interface TabContentProps {
     tabs: Tab[];
     activeTabId: string;
-    selectedLocation: Location;
 }
 
-const TabContent: FC<TabContentProps> = ({ tabs, activeTabId, selectedLocation }) => {
+const TabContent: FC<TabContentProps> = ({ tabs, activeTabId }) => {
     return (
         <div className="flex-grow relative">
             {tabs.map((tab) => (
@@ -24,7 +22,7 @@ const TabContent: FC<TabContentProps> = ({ tabs, activeTabId, selectedLocation }
                     transition={{ duration: 0.3 }}
                     style={{ width: "100%", height: "100%" }}
                 >
-                    {tab.content(selectedLocation)}
+                    {tab.content()}
                 </motion.div>
             ))}
         </div>

--- a/src/components/app/gs-scheduler/TabNav.tsx
+++ b/src/components/app/gs-scheduler/TabNav.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from "react";
-import {Location} from "@/api/gs-locations";
 import { Plus } from "lucide-react";
 
 interface TabNavProps {
@@ -13,7 +12,7 @@ interface TabNavProps {
 export interface Tab {
     id: string;
     name: string;
-    content: (location: Location) => React.ReactElement;
+    content: () => React.ReactElement;
     isPinned?: boolean;
 }
 


### PR DESCRIPTION
### Purpose for PR
ss-web initially hardcoded values for groundstations, instead of fetching from the API.

### What changed?
Deleted passing locations through classes. Moved calling the api for groundstations only in the request forms. 
Implements using the API wrapper from @dzinkiv to fetch from API. 

### Limitations and Problems
ss-core needs to adapt the response from ss-web to change from station name to groundstation id. 